### PR TITLE
Remove applyRequiredProperties method

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@apib/2postman",
   "description": "Convert API Blueprints to Postman Collections",
   "author": "Johnson Controls, Plc.",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "BSD",
   "dependencies": {
     "apib-include-directive": "^0.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -231,23 +231,11 @@ function parseBodyTests(content) {
   return tests[1].split(/\r\n?|\n/g);
 }
 
-function applyRequiredProperties(obj) {
-  if (obj.properties) {
-    obj.required = Object.getOwnPropertyNames(obj.properties);
-  }
-
-  _.forOwn(obj, value => {
-    _.isObjectLike(value) && applyRequiredProperties(value);
-  });
-}
-
 function parseJsonSchema(content) {
   try {
     const schema = JSON.parse(parseContent(content, 'messageBodySchema').content);
 
     if (schema) {
-      applyRequiredProperties(schema);
-
       return schema;
     }
   } catch (e) {}

--- a/templates/postman/actions/js-tests.hbs
+++ b/templates/postman/actions/js-tests.hbs
@@ -18,6 +18,9 @@ try {
         const self = Url.parse(jsonData.self);
         const current = pm.request.url.toJSON();
 
+        _.mapValues(self.query, function(x) { x.value = x.value.toLowerCase() });
+        _.mapValues(current.query, function(x) { x.value = x.value.toLowerCase() });
+        
         const pathDiffs = _.difference(self.path, current.path);
         const queryDiffs = _.differenceWith(self.query, current.query, _.isEqual);
 


### PR DESCRIPTION
## Description
* Remove applyRequiredProperties method in index.js. The document should explicitly call out required and optional properties, instead of the tool.
* Use case insensitive compare for self link test.
